### PR TITLE
feature: make encType/addr/realm/domain configrable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ The Realm name used is also available from the KDC instance:
 ```go
 kdc.Realm
 ```
+
+You can also customize the mock KDC by modifying the global variables below.
+```golang
+ServerEncType = "aes256-cts-hmac-sha1-96" // encrypt type supported in KDC
+ServerAddr    = "127.0.0.1:0"             // server address of KDC
+ServerRealm   = "TEST.REALM.COM"          // Realm of KDC
+ServerDomain  = "test.realm.com"          // Domain of KDC
+```

--- a/README.md
+++ b/README.md
@@ -46,10 +46,14 @@ The Realm name used is also available from the KDC instance:
 kdc.Realm
 ```
 
-You can also customize the mock KDC by modifying the global variables below.
+You can also customize the mock KDC by `Option` like below code:
+
 ```golang
-ServerEncType = "aes256-cts-hmac-sha1-96" // encrypt type supported in KDC
-ServerAddr    = "127.0.0.1:0"             // server address of KDC
-ServerRealm   = "TEST.REALM.COM"          // Realm of KDC
-ServerDomain  = "test.realm.com"          // Domain of KDC
+kdc, err := NewKDC(
+    p, l,
+    WithEncType("aes256-cts-hmac-sha1-96"), // customize encrypt type supported in mock KDC
+    WithSrvAddr("127.0.0.1:0"),             // customize server addr of mock KDC
+    WithRealm("TEST.REALM.COM"),            // customize realm of mock KDC
+    WithDomain("test.realm.com"),           // customize domain of mock KDC
+)
 ```

--- a/kdc.go
+++ b/kdc.go
@@ -29,10 +29,10 @@ import (
 )
 
 var (
-	ServerEncType = "aes256-cts-hmac-sha1-96"
-	ServerAddr    = "127.0.0.1:0"
-	ServerRealm   = "TEST.REALM.COM"
-	ServerDomain  = "test.realm.com"
+	ServerEncType = "aes256-cts-hmac-sha1-96" // encrypt type supported in KDC
+	ServerAddr    = "127.0.0.1:0"             // server address of KDC
+	ServerRealm   = "TEST.REALM.COM"          // Realm of KDC
+	ServerDomain  = "test.realm.com"          // Domain of KDC
 )
 
 type KDC struct {

--- a/kdc.go
+++ b/kdc.go
@@ -28,9 +28,11 @@ import (
 	"github.com/jcmturner/gokrb5/v8/types"
 )
 
-const (
-	encType = "aes256-cts-hmac-sha1-96"
-	srealm  = "TEST.REALM.COM"
+var (
+	ServerEncType = "aes256-cts-hmac-sha1-96"
+	ServerAddr    = "127.0.0.1:0"
+	ServerRealm   = "TEST.REALM.COM"
+	ServerDomain  = "test.realm.com"
 )
 
 type KDC struct {
@@ -58,7 +60,7 @@ type PrincipalDetails struct {
 
 func NewKDC(principals map[string][]string, l *log.Logger) (*KDC, error) {
 	kdc := new(KDC)
-	kdc.Realm = strings.ToUpper(srealm)
+	kdc.Realm = strings.ToUpper(ServerRealm)
 	kdc.Logger = l
 	kdc.errChan = make(chan error, 1)
 	kdc.udpClose = make(chan interface{})
@@ -76,7 +78,7 @@ func NewKDC(principals map[string][]string, l *log.Logger) (*KDC, error) {
 	}
 
 	var err error
-	kdc.TCPListener, err = net.Listen("tcp", "127.0.0.1:0")
+	kdc.TCPListener, err = net.Listen("tcp", ServerAddr)
 	if err != nil {
 		return nil, fmt.Errorf("could not create TCP listener: %v", err)
 	}
@@ -87,23 +89,23 @@ func NewKDC(principals map[string][]string, l *log.Logger) (*KDC, error) {
 
 	// Generate the krb5 config object
 	kdc.KRB5Conf = config.New()
-	encTypeID := etypeID.ETypesByName[encType]
-	kdc.KRB5Conf.LibDefaults.DefaultTGSEnctypes = []string{encType}
+	encTypeID := etypeID.ETypesByName[ServerEncType]
+	kdc.KRB5Conf.LibDefaults.DefaultTGSEnctypes = []string{ServerEncType}
 	kdc.KRB5Conf.LibDefaults.DefaultTGSEnctypeIDs = []int32{encTypeID}
-	kdc.KRB5Conf.LibDefaults.DefaultTktEnctypes = []string{encType}
+	kdc.KRB5Conf.LibDefaults.DefaultTktEnctypes = []string{ServerEncType}
 	kdc.KRB5Conf.LibDefaults.DefaultTktEnctypeIDs = []int32{encTypeID}
-	kdc.KRB5Conf.LibDefaults.PermittedEnctypes = []string{encType}
+	kdc.KRB5Conf.LibDefaults.PermittedEnctypes = []string{ServerEncType}
 	kdc.KRB5Conf.LibDefaults.PermittedEnctypeIDs = []int32{encTypeID}
 	kdc.KRB5Conf.LibDefaults.PreferredPreauthTypes = []int{int(encTypeID)}
 	kdc.KRB5Conf.LibDefaults.DefaultRealm = kdc.Realm
 	kdc.KRB5Conf.LibDefaults.DNSLookupKDC = false
 	kdc.KRB5Conf.LibDefaults.DNSLookupRealm = false
 
-	kdc.KRB5Conf.DomainRealm[strings.ToLower(srealm)] = kdc.Realm
+	kdc.KRB5Conf.DomainRealm[strings.ToLower(ServerRealm)] = kdc.Realm
 
 	kdc.KRB5Conf.Realms = append(kdc.KRB5Conf.Realms, config.Realm{
 		Realm:         kdc.Realm,
-		DefaultDomain: "test.realm.com",
+		DefaultDomain: ServerDomain,
 		KDC:           []string{kdc.TCPListener.Addr().String()},
 	})
 

--- a/kdc_test.go
+++ b/kdc_test.go
@@ -16,7 +16,13 @@ func TestNewKDC(t *testing.T) {
 	p := make(map[string][]string)
 	p["testuser1"] = []string{"testgroup1"}
 	p["HTTP/host.test.realm.com"] = []string{}
-	kdc, err := NewKDC(p, l)
+	kdc, err := NewKDC(
+		p, l,
+		WithEncType(DEFAULT_ENC_TYPE),
+		WithSrvAddr(DEFAULT_ADDR),
+		WithRealm(DEFAULT_REALM),
+		WithDomain(DEFAULT_DOMAIN),
+	)
 	if err != nil {
 		t.Fatalf("could not create test KDC: %v", err)
 	}


### PR DESCRIPTION
I wanted to use this mocktest in our project tests, but I found that there were a lot of global variables that I couldn't customize, which made me unable to use them well. So I changed some variables (such as ServerAddr) to be modifiable outside the package
